### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,57 +5,57 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-BitInt		KEYWORD1
+BitInt	KEYWORD1
 BitIntMember	KEYWORD1
 buint8_t	KEYWORD1
 buint16_t	KEYWORD1
 buint32_t	KEYWORD1
 buint64_t	KEYWORD1
-bint8_t		KEYWORD1
+bint8_t	KEYWORD1
 bint16_t	KEYWORD1
 bint32_t	KEYWORD1
 bint64_t	KEYWORD1
 initializer_list	KEYWORD1
 LedMatrix	KEYWORD1
-RowCol		KEYWORD1
-Col		KEYWORD1
-Row		KEYWORD1
+RowCol	KEYWORD1
+Col	KEYWORD1
+Row	KEYWORD1
 MatrixCascade	KEYWORD1
 RowColIterator	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin		KEYWORD2
-clear		KEYWORD2
-cols		KEYWORD2
+begin	KEYWORD2
+clear	KEYWORD2
+cols	KEYWORD2
 combineCascades	KEYWORD2
-end		KEYWORD2
-fill		KEYWORD2
-get		KEYWORD2
-getCol		KEYWORD2
+end	KEYWORD2
+fill	KEYWORD2
+get	KEYWORD2
+getCol	KEYWORD2
 getRotation	KEYWORD2
-getRow		KEYWORD2
-index		KEYWORD2
-invert		KEYWORD2
+getRow	KEYWORD2
+index	KEYWORD2
+invert	KEYWORD2
 invertCol	KEYWORD2
 invertRow	KEYWORD2
-off		KEYWORD2
-on		KEYWORD2
+off	KEYWORD2
+on	KEYWORD2
 resetRotation	KEYWORD2
-rows		KEYWORD2
-set		KEYWORD2
-setCol		KEYWORD2
+rows	KEYWORD2
+set	KEYWORD2
+setCol	KEYWORD2
 setIntensity	KEYWORD2
 setRotation	KEYWORD2
-setRow		KEYWORD2
+setRow	KEYWORD2
 shiftDown	KEYWORD2
 shiftLeft	KEYWORD2
 shiftRight	KEYWORD2
-shiftUp		KEYWORD2
+shiftUp	KEYWORD2
 shutdown	KEYWORD2
-size		KEYWORD2
-wakeup		KEYWORD2
+size	KEYWORD2
+wakeup	KEYWORD2
 #######################################
 # Instances (KEYWORD2)
 #######################################


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords